### PR TITLE
Add disk space reporting XAPI plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ $ xe host-call-plugin host-uuid=<uuid> plugin=lsblk.py fn=list_block_devices
 
 ## Smartctl parser
 
-This XAPI plugin provides information and health details for the physical disks on the host. 
+This XAPI plugin provides information and health details for the physical disks on the host.
 
 It uses the `smartctl --scan` command to retrieve the list of devices. For devices managed by
 MegaRAID, the device names may be identical. To handle this, the plugin returns information
@@ -447,6 +447,19 @@ $ xe host-call-plugin host-uuid=<uuid> plugin=sdncontroller.py args:bridge=xenbr
   "stderr": "ovs-ofctl: xenbr10 is not a bridge or a socket\n",
   "stdout": ""
 }
+```
+
+## VM disk space
+
+A XAPI plugin that queries the in-VM status of mounted volumes and their free space.
+
+### `vm_get_disk_space`
+
+Query the mounted volumes of VMs with the specified UUIDs (comma-separated).
+
+```
+$ xe host-call-plugin host-uuid=<uuid> plugin=vm_disk_space.py fn=vm_get_disk_space args:vm_uuids=<vm1>,<vm2>
+{"<vm1>": [{"driveletter": "C:", "filesystem": "NTFS", "name": "\\\\?\\Volume{5989a8d9-8809-410e-b9ea-1246b17ce272}\\", "volume_name": "", "free": 16663056384, "size": 33685499904, "extents": [{"": "xvda", "diskid": 0, "length": 33685504000, "offset": 122683392, "target": 0}], "mount_points": ["C:\\"]}, {"driveletter": "", "filesystem": "NTFS", "name": "\\\\?\\Volume{4cbc9991-9ed1-4527-a3a4-29d1b6d451c2}\\", "volume_name": "", "free": 89468928, "size": 549449728, "extents": [{"": "xvda", "diskid": 0, "length": 549453824, "offset": 33808187392, "target": 0}]}, {"driveletter": "", "filesystem": "FAT32", "name": "\\\\?\\Volume{8d79687c-caff-4b4f-beb4-31038b6468c2}\\", "volume_name": "", "free": 71124992, "size": 100663296, "extents": [{"": "xvda", "diskid": 0, "length": 104857600, "offset": 1048576, "target": 0}]}, {"driveletter": "D:", "filesystem": "", "name": "\\\\?\\Volume{12050cbd-7c8f-11ef-8f8d-806e6f6e6963}\\", "volume_name": "", "free": 0, "size": 0, "extents": [{"": "xvdd", "target": 3}], "mount_points": ["D:\\"]}], "<vm2>": [{"driveletter": null, "filesystem": null, "name": "/dev/xvda1", "volume_name": null, "free": 2005835776, "size": 1048576, "extents": [{"": "xvda"}]}, {"driveletter": null, "filesystem": "ext4", "name": "/dev/xvda2(8f6d7cd7-4435-4f3a-9811-ba9c957a45b4)", "volume_name": null, "free": 17410891776, "size": 26841431552, "extents": [{"": "xvda"}], "mount_points": ["/"]}]}
 ```
 
 ## Tests

--- a/SOURCES/etc/xapi.d/plugins/vm_disk_space.py
+++ b/SOURCES/etc/xapi.d/plugins/vm_disk_space.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import json
+
+import xcp.environ
+import XenAPIPlugin
+
+from xcpngutils import error_wrapped
+from xcpngutils.xenstore import xs_join, xs_open, xs_read, xs_transaction
+
+
+def extent_get(xs, tx, extent_path):
+    extent_key = xs_read(xs, tx, extent_path)
+    extent = {"": extent_key}
+    for prop in ["diskid", "length", "offset", "target"]:
+        number = xs_read(xs, tx, xs_join(extent_path, prop))
+        if number is not None:
+            try:
+                extent[prop] = int(number)
+            except ValueError:
+                pass
+    return extent
+
+
+def volume_list_extents(xs, tx, extents_path, extent_ids):
+    for extent_id in extent_ids:
+        extent_path = xs_join(extents_path, extent_id)
+        yield extent_get(xs, tx, extent_path)
+
+
+def volume_list_mountpoints(xs, tx, mountpoints_path, mountpoint_ids):
+    for mountpoint_id in mountpoint_ids:
+        mountpoint = xs_read(xs, tx, xs_join(mountpoints_path, mountpoint_id))
+        if mountpoint is not None:
+            yield mountpoint
+
+
+def volume_get(xs, tx, volume_path):
+    volume = {}
+
+    for prop in ["driveletter", "filesystem", "name", "volume_name"]:
+        value = xs_read(xs, tx, xs_join(volume_path, prop))
+        if value is not None:
+            volume[prop] = value
+
+    for prop in ["free", "size"]:
+        number = xs_read(xs, tx, xs_join(volume_path, prop))
+        if number is not None:
+            try:
+                volume[prop] = int(number)
+            except ValueError:
+                pass
+
+    extents_path = xs_join(volume_path, "extents")
+    extent_ids = xs.ls(tx, extents_path)
+    if extent_ids is not None:
+        volume["extents"] = list(volume_list_extents(xs, tx, extents_path, extent_ids))
+
+    mountpoints_path = xs_join(volume_path, "mount_points")
+    mountpoint_ids = xs.ls(tx, mountpoints_path)
+    if mountpoint_ids is not None:
+        volume["mount_points"] = list(
+            volume_list_mountpoints(xs, tx, mountpoints_path, mountpoint_ids)
+        )
+
+    return volume
+
+
+def vm_list_volumes(xs, tx, volumes_path):
+    for volume_id in xs.ls(tx, volumes_path) or []:
+        volume_path = xs_join(volumes_path, volume_id)
+        yield volume_get(xs, tx, volume_path)
+
+
+def _vm_get_disk_space(session, xs, this_host_uuid, vm_uuid):
+    vm_ref = session.xenapi.VM.get_by_uuid(vm_uuid)
+
+    resident_host_ref = session.xenapi.VM.get_resident_on(vm_ref)
+    resident_host_uuid = session.xenapi.host.get_uuid(resident_host_ref)
+    if resident_host_uuid != this_host_uuid:
+        raise Exception("VM not resident on this host")
+    domid = int(session.xenapi.VM.get_domid(vm_ref))
+
+    with xs_transaction(xs) as tx:
+        dom_path = xs.get_domain_path(domid)
+        volumes_path = xs_join(dom_path, "data/volumes")
+        return list(vm_list_volumes(xs, tx, volumes_path))
+
+
+@error_wrapped
+def vm_get_disk_space(session, args):
+    this_host_uuid = xcp.environ.readInventory()["INSTALLATION_UUID"]
+    vm_uuids = args["vm_uuids"].split(",")
+    with xs_open() as xs:
+        return json.dumps(
+            dict(
+                (vm_uuid, _vm_get_disk_space(session, xs, this_host_uuid, vm_uuid))
+                for vm_uuid in vm_uuids
+            )
+        )
+
+
+if __name__ == "__main__":
+    XenAPIPlugin.dispatch({"vm_get_disk_space": vm_get_disk_space})

--- a/SOURCES/etc/xapi.d/plugins/xcpngutils/xenstore.py
+++ b/SOURCES/etc/xapi.d/plugins/xcpngutils/xenstore.py
@@ -1,0 +1,42 @@
+import contextlib
+
+
+@contextlib.contextmanager
+def xs_open():
+    import xen.lowlevel.xs
+
+    xs = xen.lowlevel.xs.xs()
+    try:
+        yield xs
+    finally:
+        xs.close()
+
+
+@contextlib.contextmanager
+def xs_transaction(xs):
+    tx = xs.transaction_start()
+    try:
+        yield tx
+    finally:
+        xs.transaction_end(tx)
+
+
+def xs_join(a, b):
+    if a is None:
+        a = ""
+    if b and b.startswith("/"):
+        raise Exception("attempting to join an absolute path")
+    if not b:
+        return a.rstrip("/")
+    elif a.endswith("/"):
+        return a + b
+    else:
+        return a + "/" + b
+
+
+def xs_read(xs, tx, path):
+    data = xs.read(tx, path)
+    if data is None:
+        return None
+    else:
+        return data.decode()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import sys
 
 import mocked_configparser
 import mocked_xen_api_plugin
+import mocked_xcp
 import mocked_yum
 
 def pytest_configure():
@@ -17,6 +18,9 @@ sys.modules['ConfigParser'] = mocked_configparser
 
 # Mock yum globally, module is not necessarily present on the system.
 sys.modules['yum'] = mocked_yum
+
+# Not installed.
+sys.modules['xcp'] = mocked_xcp
 
 sys.path.append(str(pathlib.Path(__file__).parent.resolve()) + '/../SOURCES/etc/xapi.d/plugins')
 

--- a/tests/mocked_xcp/environ.py
+++ b/tests/mocked_xcp/environ.py
@@ -1,0 +1,2 @@
+def readInventory():
+    return {"INSTALLATION_UUID": "9724a1cf-0673-4f28-a25a-fb2aa723f2f4"}

--- a/tests/mocked_xs.py
+++ b/tests/mocked_xs.py
@@ -1,0 +1,75 @@
+class Xs:
+    def __init__(self, data):
+        """
+        Create a mock Xs object.
+
+        Parameters
+        ----------
+        data: dict
+            Nested dictionary of Xenstore elements, with "" being the key of an
+            element if that element has a child.
+
+        """
+        self._data = data
+        self._tx = 0
+        self._txs = set()
+
+    def close(self):
+        self._data = None
+        self._tx = 0
+        self._txs = set()
+
+    def get_domain_path(self, domid):
+        assert isinstance(domid, int)
+        return "/local/domain/{0}".format(domid)
+
+    def transaction_start(self):
+        tx = str(self._tx)
+        self._txs.add(tx)
+        self._tx += 1
+        return tx
+
+    def transaction_end(self, tx):
+        self._txs.remove(tx)
+
+    @staticmethod
+    def _explode(path):
+        assert path
+        if not path.startswith("/"):
+            path = "/local/domain/0" + path
+        return path.strip("/").split("/")
+
+    def _traverse(self, segs):
+        current = self._data
+        while segs:
+            if current is None or isinstance(current, str):
+                current = None
+                break
+            current = current.get(segs[0])
+            segs = segs[1:]
+        return current
+
+    def ls(self, tx, path):
+        assert self._data is not None
+        assert tx in self._txs
+        segs = self._explode(path)
+        current = self._traverse(segs)
+        if current is None:
+            return None
+        return list(filter(lambda key: bool(key), current.keys()))
+
+    def read(self, tx, path):
+        assert self._data is not None
+        assert tx in self._txs
+        segs = self._explode(path)
+        current = self._traverse(segs)
+        if isinstance(current, str):
+            return current.encode()
+        elif current is None:
+            return current
+        else:
+            data = current.get("")
+            if data is None:
+                return None
+            else:
+                return data.encode()

--- a/tests/test_vm_disk_space.py
+++ b/tests/test_vm_disk_space.py
@@ -1,0 +1,158 @@
+import pytest
+import mocked_xs
+
+from vm_disk_space import vm_list_volumes, volume_get
+
+DATA = {
+    "local": {
+        "domain": {
+            "1": {
+                "data": {
+                    "volumes": {
+                        "0": {
+                            "driveletter": "C:",
+                            "extents": {
+                                "0": {
+                                    "": "xvda",
+                                    "diskid": "0",
+                                    "length": "33685504000",
+                                    "offset": "122683392",
+                                    "target": "0",
+                                }
+                            },
+                            "filesystem": "NTFS",
+                            "free": "16663138304",
+                            "mount_points": {
+                                "0": "C:\\",
+                            },
+                            "name": "\\\\?\\Volume{5989a8d9-8809-410e-b9ea-1246b17ce272}\\",
+                            "size": "33685499904",
+                            "volume_name": "",
+                        },
+                        "1": {
+                            "driveletter": "",
+                            "extents": {
+                                "0": {
+                                    "": "xvda",
+                                    "diskid": "0",
+                                    "length": "549453824",
+                                    "offset": "33808187392",
+                                    "target": "0",
+                                }
+                            },
+                            "filesystem": "NTFS",
+                            "free": "89468928",
+                            "name": "\\\\?\\Volume{4cbc9991-9ed1-4527-a3a4-29d1b6d451c2}\\",
+                            "size": "549449728",
+                            "volume_name": "",
+                        },
+                        "2": {
+                            "driveletter": "",
+                            "extents": {
+                                "0": {
+                                    "": "xvda",
+                                    "diskid": "0",
+                                    "length": "104857600",
+                                    "offset": "1048576",
+                                    "target": "0",
+                                }
+                            },
+                            "filesystem": "FAT32",
+                            "free": "71124992",
+                            "name": "\\\\?\\Volume{8d79687c-caff-4b4f-beb4-31038b6468c2}\\",
+                            "size": "100663296",
+                            "volume_name": "",
+                        },
+                        "3": {
+                            "driveletter": "D:",
+                            "extents": {
+                                "0": {
+                                    "": "xvdd",
+                                    "target": "3",
+                                }
+                            },
+                            "filesystem": "",
+                            "free": "0",
+                            "mount_points": {
+                                "0": "D:\\",
+                            },
+                            "name": "\\\\?\\Volume{12050cbd-7c8f-11ef-8f8d-806e6f6e6963}\\",
+                            "size": "0",
+                            "volume_name": "",
+                        },
+                    }
+                }
+            },
+            "2": {
+                "data": {
+                    "volumes": {
+                        "0": {
+                            "extents": {
+                                "0": "xvda",
+                            },
+                            "free": "2005835776",
+                            "name": "/dev/xvda1",
+                            "size": "1048576",
+                        },
+                        "1": {
+                            "extents": {
+                                "0": "xvda",
+                            },
+                            "filesystem": "ext4",
+                            "free": "17410916352",
+                            "mount_points": {
+                                "0": "/",
+                            },
+                            "name": "/dev/xvda2(8f6d7cd7-4435-4f3a-9811-ba9c957a45b4)",
+                            "size": "26841431552",
+                        },
+                    }
+                }
+            },
+            "3": {},
+        }
+    }
+}
+
+
+@pytest.fixture(scope="class")
+def xs():
+    return mocked_xs.Xs(DATA)
+
+
+@pytest.fixture(scope="function")
+def tx(xs):
+    tx = xs.transaction_start()
+    yield tx
+    xs.transaction_end(tx)
+
+
+class TestVmDiskSpace:
+    def test_volumes_count(self, xs, tx):
+        assert len(list(vm_list_volumes(xs, tx, "/local/domain/1/data/volumes"))) == 4
+        assert len(list(vm_list_volumes(xs, tx, "/local/domain/2/data/volumes"))) == 2
+        assert len(list(vm_list_volumes(xs, tx, "/local/domain/3/data/volumes"))) == 0
+
+    def test_volume_windows(self, xs, tx):
+        volume = volume_get(xs, tx, "/local/domain/1/data/volumes/0")
+        assert volume["driveletter"] == "C:"
+        assert len(volume["extents"]) == 1
+        assert volume["extents"][0][""] == "xvda"
+        assert volume["extents"][0]["diskid"] == 0
+        assert volume["extents"][0]["length"] == 33685504000
+        assert volume["size"] == 33685499904
+        assert volume["free"] == 16663138304
+
+    def test_volume_windows_2(self, xs, tx):
+        volume = volume_get(xs, tx, "/local/domain/1/data/volumes/1")
+        assert volume["driveletter"] == ""
+        assert "mount_points" not in volume
+
+    def test_volume_linux(self, xs, tx):
+        volume = volume_get(xs, tx, "/local/domain/2/data/volumes/0")
+        assert len(volume["extents"]) == 1
+        assert "driveletter" not in volume
+        assert volume["extents"][0][""] == "xvda"
+        assert "diskid" not in volume["extents"][0]
+        assert volume["size"] == 1048576
+        assert volume["free"] == 2005835776


### PR DESCRIPTION
This plugin adds the disk space reporting feature for VMs running XS agents.

Queries can be batched between multiple VM UUIDs on the same host to save computation.