### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,20 +1,31 @@
 name: Run unit tests
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
+    - name: checkout
+      uses: actions/checkout@v6
+
     - name: Set up Python
-      uses: actions/setup-python@v2
-    - name: Install dependencies
+      uses: LizardByte/actions/actions/setup_python@v2026.227.200013
+      with:
+        python-version: |
+          '3.6.15'
+          '3.12.13'
+
+    - name: Make XCP-ng python versions globally available 
       run: |
-        python -m pip install --upgrade pip
-        pip install mock pytest pyfakefs
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: pytest
-      run: |
-        cd tests
-        pytest
+        sudo ln -s $(pyenv root)/versions/3.6.15/bin/python3.6 /usr/bin/
+      # The following line is not needed as long as ubuntu 24.04 is used
+      # sudo ln -s $(pyenv root)/versions/3.12.13/bin/python3.12 /usr/bin/
+
+    - name: Install Environment manager
+      run: pip install wox
+
+    - name: Run unit tests
+      run: wox

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 **/__pycache__
+*.egg-info/
+build/

--- a/README.md
+++ b/README.md
@@ -451,9 +451,11 @@ $ xe host-call-plugin host-uuid=<uuid> plugin=sdncontroller.py args:bridge=xenbr
 
 ## Tests
 
-To run the plugins' unit tests you'll need to install `pytest`, `pyfakefs` and `mock`.
-
-To run all tests you can run:
-```py
-pytest tests/
+Install the test dependencies:
+```bash
+pip install --group test
+```
+and run the tests:
+```bash
+pytest
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools >= 75.3.4"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "xcp-ng-xapi-plugins"
+version = "1.16.0"
+requires-python = ">=3.6"
+authors = [{name = "XCP-ng maintainers"}]
+maintainers = [{name = "XCP-ng maintainers"}]
+description = "Plugins for xen-api installed in XCP-ng"
+readme = "README.md"
+license = "AGPL-3.0-only"
+license-files = ["LICENSE"]
+
+[project.urls]
+Homepage = "https://xcp-ng.org/"
+Repository = "https://github.com/xcp-ng/xcp-ng-xapi-plugins.git"
+Issues = "https://github.com/xcp-ng/xcp-ng-xapi-plugins/issues"
+
+[dependency-groups]
+test = ["pytest", "pyfakefs", "mock"]
+
+[pytest]
+testpaths = "tests"
+
+# Normal tooling doesn't support python 3.6, use Wox to set it up
+# XCP-ng 8.3 uses Python 3.6, XCP-ng 9.0 uses Python 3.12
+[tool.wox.showcase]
+envlist = ["py36", "py312"]
+deps = ["pytest", "pyfakefs", "mock"]
+commands = ["pytest"]
+
+[tool.wox.wox_configuration]


### PR DESCRIPTION
Create pyproject.toml to define test dependencies and configure pytest.

Change CI workflow to force Python 3.6, used in XCP-ng 8.3, Python 3.12, used in Alma 10, and update to the latest actions.

Setup is more complex than necessary, needing a custom action to install 3.6, and the tool `wox` to create the virtual environment for 3.6 and install the dependencies.