### PR TITLE
meta: add team maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+* @xcp-ng-rpms/xapi-network
+SOURCES/etc/xapi.d/plugins/lvm.py @xcp-ng-rpms/storage
+SOURCES/etc/xapi.d/plugins/sdncontroller.py @xcp-ng-rpms/xapi-network
+SOURCES/etc/xapi.d/plugins/updater.py @xcp-ng-rpms/os-platform-release


### PR DESCRIPTION
Opening this to discuss the code maintainers, I've seen 2 that look like teams other than xapi are interested in: \
- updater.py, for the platform team
- lvm.py one for the storage team, this is because the original PR mentions LINSTORE using it.
