### PR TITLE
Add storage team as code owners on several plugins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @xcp-ng-rpms/xapi-network
-SOURCES/etc/xapi.d/plugins/lvm.py @xcp-ng-rpms/storage
-SOURCES/etc/xapi.d/plugins/sdncontroller.py @xcp-ng-rpms/xapi-network
-SOURCES/etc/xapi.d/plugins/updater.py @xcp-ng-rpms/os-platform-release
+* @xcp-ng/xapi-network
+SOURCES/etc/xapi.d/plugins/lvm.py @xcp-ng/storage
+SOURCES/etc/xapi.d/plugins/sdncontroller.py @xcp-ng/xapi-network
+SOURCES/etc/xapi.d/plugins/updater.py @xcp-ng/os-platform-release

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,8 @@
 * @xcp-ng/xapi-network
+SOURCES/etc/xapi.d/plugins/lsblk.py @xcp-ng/storage
 SOURCES/etc/xapi.d/plugins/lvm.py @xcp-ng/storage
+SOURCES/etc/xapi.d/plugins/raid.py @xcp-ng/storage
 SOURCES/etc/xapi.d/plugins/sdncontroller.py @xcp-ng/xapi-network
+SOURCES/etc/xapi.d/plugins/smartctl.py @xcp-ng/storage
 SOURCES/etc/xapi.d/plugins/updater.py @xcp-ng/os-platform-release
+SOURCES/etc/xapi.d/plugins/zfs.py @xcp-ng/storage


### PR DESCRIPTION
New storage team responsabilities:
- lsblk.py
- raid.py
- smartctl.py
- zfs.py

Can be merged after: https://github.com/xcp-ng/xcp-ng-xapi-plugins/pull/62