### PR TITLE
feat(service.py):Restrict callable systemd units

### DIFF
--- a/SOURCES/etc/xapi.d/plugins/service.py
+++ b/SOURCES/etc/xapi.d/plugins/service.py
@@ -7,10 +7,14 @@ import XenAPIPlugin
 
 from xcpngutils import configure_logging, run_command, error_wrapped
 
+ALLOWED_SERVICES = {"linstor-controller", "linstor-satellite"}
+
 def run_service_command(cmd_name, args):
     service = args.get('service')
     if not service:
         raise Exception('Missing or empty argument `service`')
+    if service not in ALLOWED_SERVICES:
+        raise ValueError('This service is not whitelisted')
     run_command(['systemctl', cmd_name, service])
     return json.dumps(True)
 


### PR DESCRIPTION
Add a whitelist that limits the systemd units that can be called to "linstor-controller" and "linstor-satellite" in `service.py`. The commit ensures that the `service` argument is validated against this whitelist before any call is made.
This change eliminating the risk of arbitrary systemd unit execution by manipulating `service` argument.