### PR TITLE
meta: add storage team as code owner of service.py

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,6 @@ SOURCES/etc/xapi.d/plugins/lvm.py @xcp-ng/storage
 SOURCES/etc/xapi.d/plugins/raid.py @xcp-ng/storage
 SOURCES/etc/xapi.d/plugins/sdncontroller.py @xcp-ng/xapi-network
 SOURCES/etc/xapi.d/plugins/smartctl.py @xcp-ng/storage
+SOURCES/etc/xapi.d/plugins/service.py @xcp-ng/storage
 SOURCES/etc/xapi.d/plugins/updater.py @xcp-ng/os-platform-release
 SOURCES/etc/xapi.d/plugins/zfs.py @xcp-ng/storage


### PR DESCRIPTION
Following #69, `service.py` permit to controls only `linstor-controller` and `linstor-satellite`.

As there are storage services, give responsability of `service.py` to storage team.