### PR TITLE
CI: run tests against py27 too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,13 @@ jobs:
       uses: LizardByte/actions/actions/setup_python@v2026.227.200013
       with:
         python-version: |
+          '2.7.5'
           '3.6.15'
           '3.12.13'
 
-    - name: Make XCP-ng python versions globally available 
+    - name: Make XCP-ng python versions globally available
       run: |
+        sudo ln -s $(pyenv root)/versions/2.7.5/bin/python2.7 /usr/bin/
         sudo ln -s $(pyenv root)/versions/3.6.15/bin/python3.6 /usr/bin/
       # The following line is not needed as long as ubuntu 24.04 is used
       # sudo ln -s $(pyenv root)/versions/3.12.13/bin/python3.12 /usr/bin/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ testpaths = "tests"
 # Normal tooling doesn't support python 3.6, use Wox to set it up
 # XCP-ng 8.3 uses Python 3.6, XCP-ng 9.0 uses Python 3.12
 [tool.wox.showcase]
-envlist = ["py36", "py312"]
+envlist = ["py27", "py36", "py312"]
 deps = ["pytest", "pyfakefs", "mock"]
 commands = ["pytest"]
 


### PR DESCRIPTION
most (all ?) plugins are running on XCP-ng 8.3 using python 2.7.5, it should be tested.